### PR TITLE
refactor: abstraction AppRouter

### DIFF
--- a/lib/app/app_flutter_arch.dart
+++ b/lib/app/app_flutter_arch.dart
@@ -1,4 +1,6 @@
 import 'package:app_flutter_arch/app/core/provider/application_binding.dart';
+import 'package:app_flutter_arch/app/core/router/app_router.dart';
+import 'package:app_flutter_arch/app/core/router/navigator_app_router.dart';
 import 'package:app_flutter_arch/app/core/ui/theme/theme_config.dart';
 import 'package:app_flutter_arch/app/core/global/global_context.dart';
 import 'package:flutter/material.dart';
@@ -7,16 +9,30 @@ import 'package:flutter/material.dart';
 import 'package:app_flutter_arch/app/pages/home/home_router.dart';
 import 'package:app_flutter_arch/app/pages/splash/splash_page.dart';
 
-class AppFlutterArch extends StatelessWidget {
-  final _navKey = GlobalKey<NavigatorState>();
+class AppFlutterArch extends StatefulWidget {
+  const AppFlutterArch({
+    super.key,
+  });
 
-  AppFlutterArch({super.key}) {
-    GlobalContext.i.navigatorKey = _navKey;
+  @override
+  State<AppFlutterArch> createState() => _AppFlutterArchState();
+}
+
+class _AppFlutterArchState extends State<AppFlutterArch> {
+  final _navKey = GlobalKey<NavigatorState>();
+  late final AppRouter _appRouter;
+
+  @override
+  void initState() {
+    super.initState();
+    _appRouter = NavigatorAppRouter(navigatorStateKey: _navKey);
+    GlobalContext.i.appRouter = _appRouter;
   }
 
   @override
   Widget build(BuildContext context) {
     return ApplicationBinding(
+      appRouter: _appRouter,
       child: MaterialApp(
         title: 'Delivery App',
         theme: ThemeConfig.theme,

--- a/lib/app/core/global/global_context.dart
+++ b/lib/app/core/global/global_context.dart
@@ -1,8 +1,8 @@
+import 'package:app_flutter_arch/app/core/router/app_router.dart';
 import 'package:app_flutter_arch/app/core/ui/helpers/shared_preferences.dart';
-import 'package:flutter/material.dart';
 
 class GlobalContext {
-  late final GlobalKey<NavigatorState> _navigatorkey;
+  late final AppRouter _appRouter;
 
   static GlobalContext? _instance;
 
@@ -13,10 +13,10 @@ class GlobalContext {
     return _instance!;
   }
 
-  set navigatorKey(GlobalKey<NavigatorState> key) => _navigatorkey = key;
+  set appRouter(AppRouter appRouter) => _appRouter = appRouter;
 
   Future<void> unauthUser() async {
     await clearAllSharedPreferencesKeys();
-    _navigatorkey.currentState!.pushNamedAndRemoveUntil('/', (route) => false);
+    _appRouter.pushNamedAndRemoveUntil('/', (route) => false);
   }
 }

--- a/lib/app/core/provider/application_binding.dart
+++ b/lib/app/core/provider/application_binding.dart
@@ -1,11 +1,17 @@
 import 'package:app_flutter_arch/app/core/rest_client/custom_dio.dart';
+import 'package:app_flutter_arch/app/core/router/app_router.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class ApplicationBinding extends StatelessWidget {
+  final AppRouter appRouter;
   final Widget child;
 
-  const ApplicationBinding({super.key, required this.child});
+  const ApplicationBinding({
+    super.key,
+    required this.child,
+    required this.appRouter,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -13,7 +19,10 @@ class ApplicationBinding extends StatelessWidget {
       providers: [
         Provider(
           create: (context) => CustomDio(),
-        )
+        ),
+        Provider(
+          create: (context) => appRouter,
+        ),
       ],
       child: child,
     );

--- a/lib/app/core/router/app_router.dart
+++ b/lib/app/core/router/app_router.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/widgets.dart';
+
+abstract class AppRouter {
+  Future<T?> popAndPushNamed<T extends Object?, TO extends Object?>(
+    String routeName, {
+    TO? result,
+  });
+
+  Future<T?> pushNamedAndRemoveUntil<T extends Object?>(
+    String routeName,
+    RoutePredicate routePredicate,
+  );
+}

--- a/lib/app/core/router/app_router_extensions.dart
+++ b/lib/app/core/router/app_router_extensions.dart
@@ -1,0 +1,31 @@
+import 'package:app_flutter_arch/app/core/router/app_router.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+extension AppRouterBuildContextExtension on BuildContext {
+  AppRouter get appRouter => read<AppRouter>();
+
+  Future<T?> popAndPushNamed<T extends Object?, TO extends Object?>(
+    String routeName, {
+    TO? result,
+  }) {
+    return appRouter.popAndPushNamed<T, TO>(
+      routeName,
+      result: result,
+    );
+  }
+}
+
+extension AppRouterStateExtension on State {
+  AppRouter get appRouter => context.appRouter;
+
+  Future<T?> popAndPushNamed<T extends Object?, TO extends Object?>(
+    String routeName, {
+    TO? result,
+  }) {
+    return context.popAndPushNamed(
+      routeName,
+      result: result,
+    );
+  }
+}

--- a/lib/app/core/router/navigator_app_router.dart
+++ b/lib/app/core/router/navigator_app_router.dart
@@ -1,0 +1,34 @@
+import 'package:app_flutter_arch/app/core/router/app_router.dart';
+import 'package:flutter/widgets.dart';
+
+class NavigatorAppRouter implements AppRouter {
+  final GlobalKey<NavigatorState> navigatorStateKey;
+
+  NavigatorAppRouter({
+    required this.navigatorStateKey,
+  });
+
+  NavigatorState? get navigatorState => navigatorStateKey.currentState;
+
+  @override
+  Future<T?> popAndPushNamed<T extends Object?, TO extends Object?>(
+    String routeName, {
+    TO? result,
+  }) async {
+    return navigatorState?.popAndPushNamed<T, TO>(
+      routeName,
+      result: result,
+    );
+  }
+
+  @override
+  Future<T?> pushNamedAndRemoveUntil<T extends Object?>(
+    String routeName,
+    RoutePredicate routePredicate,
+  ) async {
+    return navigatorState?.pushNamedAndRemoveUntil<T>(
+      routeName,
+      routePredicate,
+    );
+  }
+}

--- a/lib/app/pages/home/home_page.dart
+++ b/lib/app/pages/home/home_page.dart
@@ -19,8 +19,8 @@ class _HomePageState extends BaseState<HomePage, HomeController> {
   final _loginFormKey = GlobalKey<FormState>();
   final TextEditingController userController = TextEditingController();
   final TextEditingController passwordController = TextEditingController();
-  late FocusNode userFocusNode;
-  late FocusNode passwordFocusNode;
+  late FocusNode userFocusNode = FocusNode();
+  late FocusNode passwordFocusNode = FocusNode();
 
   //se onReady não funcionar, utilize:
   // @override
@@ -33,8 +33,6 @@ class _HomePageState extends BaseState<HomePage, HomeController> {
   @override
   void onReady() {
     controller.loadItems();
-    userFocusNode = FocusNode();
-    passwordFocusNode = FocusNode();
   }
 
   @override

--- a/lib/app/pages/splash/splash_page.dart
+++ b/lib/app/pages/splash/splash_page.dart
@@ -1,6 +1,6 @@
+import 'package:app_flutter_arch/app/core/router/app_router_extensions.dart';
 import 'package:app_flutter_arch/app/core/ui/helpers/size_extensions.dart';
 import 'package:app_flutter_arch/app/core/ui/widgets/button_example.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter/material.dart';
 
 class SplashPage extends StatelessWidget {
@@ -45,7 +45,7 @@ class SplashPage extends StatelessWidget {
                     height: 35,
                     label: 'Ir para home',
                     onPressed: () {
-                      Navigator.of(context).popAndPushNamed('/home');
+                      context.popAndPushNamed('/home');
                     },
                   )
                 ],


### PR DESCRIPTION
A ideia é abstrair para os widgets qual ferramenta estamos usando para a navegação. No momento estamos usando o `Navigator` (a ferramenta "nativa" do flutter), porém, se um dia quisermos trocar de ferramenta, por exemplo, começar a usar o Modular ou o GoRouter por algum motivo, com essa abstração não vamos precisar sair por todo o código substituir a linha da navegação. 

Então a ideia aqui foi criar uma classe abstrata chamada `AppRouter`, e uma classe `NavigatorAppRouter` implementando.

Se trocarmos para o GoRouter, a ideia seria só criar o `GoRouterAppRouter` que implementaria o `AppRouter`, e prover essa nova classe no lugar do `NavigatorAppRouter`.

Estamos tendo essa experiência no projeto q tô trabalhando de considerar trocar a ferramenta do Modular para outra que seja mais fácil nos testes. Mas não criamos essa abstração ainda, então, se decidirmos trocar mesmo, vamos ter q modificar muitas linhas e testes que estão referenciando direto o Modular.

Se gostar da ideia, poodemos considerar criar uma abstração para a Injeção de Dependência/Provider tbm. O que acha?