### PR TITLE
refactor: remoteDataSource

### DIFF
--- a/lib/app/data_sources/remote_data_source/remote_data_source.dart
+++ b/lib/app/data_sources/remote_data_source/remote_data_source.dart
@@ -1,0 +1,5 @@
+import 'package:app_flutter_arch/app/models/model_example.dart';
+
+abstract class RemoteDataSource {
+  Future<List<ModelExample>> findAllItems();
+}

--- a/lib/app/data_sources/remote_data_source/remote_data_source_impl.dart
+++ b/lib/app/data_sources/remote_data_source/remote_data_source_impl.dart
@@ -1,0 +1,24 @@
+import 'package:app_flutter_arch/app/core/rest_client/custom_dio.dart';
+import 'package:app_flutter_arch/app/data_sources/remote_data_source/remote_data_source.dart';
+import 'package:app_flutter_arch/app/models/model_example.dart';
+
+class RemoteDataSourceImpl implements RemoteDataSource {
+  //Vale criar uma abstração para a classe de network? Por exemplo, um criar uma
+  //classe abstrata do tipo NetworkHttpClient e uma classe DioNetworkHttpClient,
+  //dessa forma, temos mais liberadade de trocar o Dio por outra ferramenta
+  final CustomDio dio;
+
+  RemoteDataSourceImpl({
+    required this.dio,
+  });
+
+  @override
+  Future<List<ModelExample>> findAllItems() async {
+    final result = await dio.unauth().get('/endpoint');
+    return await result.data
+        .map<ModelExample>(
+          (p) => ModelExample.fromMap(p),
+        )
+        .toList();
+  }
+}

--- a/lib/app/pages/home/home_router.dart
+++ b/lib/app/pages/home/home_router.dart
@@ -1,3 +1,5 @@
+import 'package:app_flutter_arch/app/data_sources/remote_data_source/remote_data_source.dart';
+import 'package:app_flutter_arch/app/data_sources/remote_data_source/remote_data_source_impl.dart';
 import 'package:app_flutter_arch/app/pages/home/home_controller.dart';
 import 'package:app_flutter_arch/app/pages/home/home_page.dart';
 import 'package:app_flutter_arch/app/repositories/repositoryExample/repository_example.dart';
@@ -10,9 +12,14 @@ class HomeRouter {
 
   static Widget get page => MultiProvider(
         providers: [
+          Provider<RemoteDataSource>(
+            create: (context) => RemoteDataSourceImpl(
+              dio: context.read(),
+            ),
+          ),
           Provider<RepositoryExample>(
             create: (context) => RepositoryExampleImpl(
-              dio: context.read(),
+              remoteDataSource: context.read(),
             ),
           ),
           Provider(

--- a/lib/app/repositories/repositoryExample/repository_example_impl.dart
+++ b/lib/app/repositories/repositoryExample/repository_example_impl.dart
@@ -1,26 +1,24 @@
 import 'dart:developer';
 
-import 'package:dio/dio.dart';
+import 'package:app_flutter_arch/app/data_sources/remote_data_source/remote_data_source.dart';
 import 'package:app_flutter_arch/app/models/model_example.dart';
 
 import '../../core/exceptions/repository_exception.dart';
-import '../../core/rest_client/custom_dio.dart';
 import './repository_example.dart';
 
 class RepositoryExampleImpl implements RepositoryExample {
-  final CustomDio dio;
-  RepositoryExampleImpl({required this.dio});
+  final RemoteDataSource remoteDataSource;
+
+  RepositoryExampleImpl({
+    required this.remoteDataSource,
+  });
 
   @override
   Future<List<ModelExample>> findAllItems() async {
     try {
-      final result = await dio.unauth().get('/endpoint');
-      return result.data
-          .map<ModelExample>(
-            (p) => ModelExample.fromMap(p),
-          )
-          .toList();
-    } on DioException catch (e, s) {
+      //TODO: check if network is available. If not, get from localRemoteDataSource
+      return await remoteDataSource.findAllItems();
+    } catch (e, s) {
       log('Erro ao buscar items', error: e, stackTrace: s);
       throw RepositoryException(message: 'Erro ao buscar items');
     }


### PR DESCRIPTION
Como no projeto que vou trabalhar vai necessitar que o `Repository` absorva mais responsabilidades, acho que vai ser melhor criar "mais um nível/camada". A camada de `DataSources`. Aí o `Repository` vai crescer mais saudável.

Com mais uma camada, acho que vai valer repensar um pouco na estrutura de pastas pra `repositories` e `data_sources` ficarem dentro de uma mesma estrutura de `data` (que é normalmente como chamamos essa parte na Clean Architecture). O que acha?