### PR TITLE
refactor: "sub-widgets" home

### DIFF
--- a/lib/app/core/ui/base_state/base_page.dart
+++ b/lib/app/core/ui/base_state/base_page.dart
@@ -1,0 +1,7 @@
+import 'package:app_flutter_arch/app/core/ui/base_state/base_state.dart';
+import 'package:app_flutter_arch/app/core/ui/base_state/state_with_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+abstract class BasePage<T extends StatefulWidget, C extends BlocBase>
+    extends BaseState<T> with StateWithController<T, C> {}

--- a/lib/app/core/ui/base_state/base_state.dart
+++ b/lib/app/core/ui/base_state/base_state.dart
@@ -1,17 +1,13 @@
+import 'package:app_flutter_arch/app/core/ui/helpers/loader.dart';
+import 'package:app_flutter_arch/app/core/ui/helpers/messages.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
-import '../helpers/loader.dart';
-import '../helpers/messages.dart';
-
-abstract class BaseState<T extends StatefulWidget, C extends BlocBase>
-    extends State<T> with Loader, Messages {
-  late final C controller;
+abstract class BaseState<T extends StatefulWidget> extends State<T>
+    with Loader, Messages {
 
   @override
   void initState() {
     super.initState();
-    controller = context.read<C>();
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
       onReady();
     });

--- a/lib/app/core/ui/base_state/state_with_controller.dart
+++ b/lib/app/core/ui/base_state/state_with_controller.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+mixin StateWithController<T extends StatefulWidget, C extends BlocBase>
+    on State<T> {
+  late final C controller;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    controller = context.read<C>();
+  }
+}

--- a/lib/app/pages/home/home_controller.dart
+++ b/lib/app/pages/home/home_controller.dart
@@ -28,4 +28,19 @@ class HomeController extends Cubit<HomeState> {
       );
     }
   }
+
+  Future<void> login({
+    required String? user,
+    required String? password,
+  }) async {
+    if (user?.isNotEmpty != true && password?.isNotEmpty != true) {
+      emit(state.copyWith(
+        status: HomeStateStatus.error,
+        errorMessage: "Preencha todos os campos.",
+      ));
+      emit(state.copyWith(
+        status: HomeStateStatus.noError,
+      ));
+    }
+  }
 }

--- a/lib/app/pages/home/home_page.dart
+++ b/lib/app/pages/home/home_page.dart
@@ -1,12 +1,11 @@
-import 'package:app_flutter_arch/app/core/ui/helpers/size_extensions.dart';
 import 'package:app_flutter_arch/app/core/ui/widgets/app_bar_example.dart';
-import 'package:app_flutter_arch/app/core/ui/widgets/generic_input.dart';
 import 'package:app_flutter_arch/app/pages/home/home_controller.dart';
 import 'package:app_flutter_arch/app/pages/home/home_state.dart';
+import 'package:app_flutter_arch/app/pages/home/widgets/home_body.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import '../../core/ui/base_state/base_state.dart';
+import '../../core/ui/base_state/base_page.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -15,47 +14,11 @@ class HomePage extends StatefulWidget {
   State<HomePage> createState() => _HomePageState();
 }
 
-class _HomePageState extends BaseState<HomePage, HomeController> {
-  final _loginFormKey = GlobalKey<FormState>();
-  final TextEditingController userController = TextEditingController();
-  final TextEditingController passwordController = TextEditingController();
-  late FocusNode userFocusNode;
-  late FocusNode passwordFocusNode;
-
-  //se onReady não funcionar, utilize:
-  // @override
-  // void initState() {
-  //   super.initState();
-  //   userFocusNode = FocusNode();
-  //   passwordFocusNode = FocusNode();
-  // }
+class _HomePageState extends BasePage<HomePage, HomeController> {
 
   @override
   void onReady() {
     controller.loadItems();
-    userFocusNode = FocusNode();
-    passwordFocusNode = FocusNode();
-  }
-
-  @override
-  void dispose() {
-    userFocusNode.dispose();
-    passwordFocusNode.dispose();
-    super.dispose();
-  }
-
-  Future<void> _onLoginButtonPressed() async {
-    var credentials = {
-      'user': userController.text,
-      'password': passwordController.text
-    };
-
-    var user = credentials['user'];
-    var password = credentials['password'];
-
-    if (user == null || user.isEmpty || password == null || password.isEmpty) {
-      return showInfo('Preencha todos os campos.');
-    }
   }
 
   @override
@@ -79,36 +42,7 @@ class _HomePageState extends BaseState<HomePage, HomeController> {
           loaded: () => true,
         ),
         builder: (context, state) {
-          return Column(
-            children: [
-              Form(
-                key: _loginFormKey,
-                child: Column(
-                  children: [
-                    Title(
-                        color: Colors.black, child: const Text('Home Example')),
-                    GenericInput(
-                      width: context.percentWidth(.9),
-                      label: 'Usuário',
-                      placeholder: 'Digite o seu usuário',
-                      controller: userController,
-                      focusNode: userFocusNode,
-                      nextFocusNode: passwordFocusNode,
-                    ),
-                    GenericInput(
-                      width: context.percentWidth(.9),
-                      label: 'Senha',
-                      placeholder: 'Digite sua senha',
-                      isPassword: true,
-                      controller: passwordController,
-                      focusNode: passwordFocusNode,
-                      onFieldSubmitted: (term) => _onLoginButtonPressed(),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          );
+          return const HomeBody();
         },
       ),
     );

--- a/lib/app/pages/home/home_state.dart
+++ b/lib/app/pages/home/home_state.dart
@@ -10,7 +10,13 @@ part 'home_state.g.dart';
 // flutter pub run build_runner watch -d
 
 @match
-enum HomeStateStatus { initial, loading, loaded, error }
+enum HomeStateStatus {
+  initial,
+  loading,
+  loaded,
+  error,
+  noError,
+}
 
 class HomeState extends Equatable {
   final HomeStateStatus status;

--- a/lib/app/pages/home/widgets/home_body.dart
+++ b/lib/app/pages/home/widgets/home_body.dart
@@ -1,0 +1,71 @@
+import 'package:app_flutter_arch/app/core/ui/base_state/base_state.dart';
+import 'package:app_flutter_arch/app/core/ui/base_state/state_with_controller.dart';
+import 'package:app_flutter_arch/app/core/ui/helpers/size_extensions.dart';
+import 'package:app_flutter_arch/app/core/ui/widgets/generic_input.dart';
+import 'package:app_flutter_arch/app/pages/home/home_controller.dart';
+import 'package:flutter/material.dart';
+
+class HomeBody extends StatefulWidget {
+  const HomeBody({
+    super.key,
+  });
+
+  @override
+  State<HomeBody> createState() => _HomeBodyState();
+}
+
+class _HomeBodyState extends BaseState<HomeBody>
+    with StateWithController<HomeBody, HomeController> {
+  final _loginFormKey = GlobalKey<FormState>();
+  final TextEditingController _userController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final FocusNode _userFocusNode = FocusNode();
+  final FocusNode _passwordFocusNode = FocusNode();
+
+  @override
+  void dispose() {
+    _userFocusNode.dispose();
+    _passwordFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Form(
+          key: _loginFormKey,
+          child: Column(
+            children: [
+              Title(color: Colors.black, child: const Text('Home Example')),
+              GenericInput(
+                width: context.percentWidth(.9),
+                label: 'Usuário',
+                placeholder: 'Digite o seu usuário',
+                controller: _userController,
+                focusNode: _userFocusNode,
+                nextFocusNode: _passwordFocusNode,
+              ),
+              GenericInput(
+                width: context.percentWidth(.9),
+                label: 'Senha',
+                placeholder: 'Digite sua senha',
+                isPassword: true,
+                controller: _passwordController,
+                focusNode: _passwordFocusNode,
+                onFieldSubmitted: (term) => _onLoginButtonPressed(),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _onLoginButtonPressed() async {
+    controller.login(
+      user: _userController.text,
+      password: _passwordController.text,
+    );
+  }
+}


### PR DESCRIPTION
A ideia desse PR foi separar a `Home` em mais widgets para ver como a arquitetura se comportava. Ao separar, achei necessário mudar algumas coisas:

## BaseState
Precisei dividir o `BaseState` em 3 partes:
    1. `BasePage`: vai ser usado para `Page` que contém sempre um _controller_ (eu imagino). Essa classe extende `BaseState` e `StateWithController`;
    2. `BaseState`: usado em pelos States que querem ter o método de `onReady` por exemplo; e
    3. `StateWithController`: um _mixin_ que contém a parte de `controller`.

Desse jeito, a gente pode ter `State` de `Page` que tem a estrutura base de um estado do projeto com controller, um `State` sem controller mas com a estrutura base de estado do projeto e um `State` que tem a base + o controller e não necesáriamente é uma `Page`. Acha que é over-engineering essa parte?

## Pasta de widgets
Precisei criar uma pasta dentro de `pages` chamada `widgets` para ser a pasta de widgets que não são a `Page` mas tbm  não serão reaproveitados por outras páginas (por isso não devem ficar `lib/app/core/ui/widgets`). Portanto, ficou assim:
```
- lib/app/pages/home/
    - HomePage.dart
    -widgets/
        - HomeBody.dart
```

Com essa modificação, acho que escalar desse jeito parece começar a ficar problemático. O que acha de mudarmos para a algo desse tipo:
```
 - lib/app/modules/home/
    - controller/home/
        - HomeController.dart
        - HomeState.dart 
        - HomeEvent.dart
    - page/home/
        - HomePage.dart
    - widgets/home_body/
        - HomeBody.dart
```

Acha que funciona? Parece mais escalável e mais fácil pra encontrar apenas as `Page` separado dos `controllers` e `widgets`.

Talvez valha a pena encaixar os `repositories` dentro dos módulos específicos tbm. Coisas compartilhadas, podem ficar num módulo de `shared`.

## HomeStateStatus.noError

Quando alterei o login pra dentro do `HomeController` , percebi que se eu submetesse o formulário com email e senha vazio duas vezes, a mensagem de erro aparece apenas 1 vez. Isso, pq o estado do BLoC emitido duas vezes é exatamente o mesmo.

No projeto q trabalho no dia a dia, nós resolvemos isso emitindo um estado logo depois e uma emissão de erro para "limpar" o status de erro. Mas uma coisa que difere lá é que nós temos um `HomeStateStatus` e um `BaseStateError` (um deles é o `BaseStateError.none`) então, é possível limpar um erro a qualquer momento sem precisar escolher um `StateStatus` diferente, saca?