### PR TITLE
refactor: base controller

### DIFF
--- a/lib/app/core/controller/base/base_controller_state.dart
+++ b/lib/app/core/controller/base/base_controller_state.dart
@@ -1,0 +1,26 @@
+import 'package:app_flutter_arch/app/core/controller/base/base_state_error.dart';
+import 'package:app_flutter_arch/app/core/result/failure.dart';
+import 'package:equatable/equatable.dart';
+
+abstract class BaseControllerState<S> extends Equatable {
+  final BaseStateError stateError;
+  final Failure? failure;
+
+  const BaseControllerState({
+    required this.stateError,
+    required this.failure,
+  });
+
+  bool get hasErrors => stateError != BaseStateError.none;
+
+  S copyWithError({
+    BaseStateError? stateError,
+    Failure? failure,
+  });
+
+  @override
+  List<Object?> get props => <Object?>[
+        stateError,
+        failure,
+      ];
+}

--- a/lib/app/core/controller/base/base_cubit_controller.dart
+++ b/lib/app/core/controller/base/base_cubit_controller.dart
@@ -1,0 +1,43 @@
+import 'package:app_flutter_arch/app/core/controller/base/base_controller_state.dart';
+import 'package:app_flutter_arch/app/core/controller/base/base_state_error.dart';
+import 'package:app_flutter_arch/app/core/result/failure.dart';
+import 'package:app_flutter_arch/app/core/result/result.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+abstract class BaseCubitController<S extends BaseControllerState>
+    extends Cubit<S> {
+  BaseCubitController(
+    super.initialState,
+  );
+
+  bool emitStateIfFailure<D>(Result<D> result) {
+    if (result.isSuccess()) return false;
+
+    final failure = result.failure!;
+    emit(state.copyWithError(
+      stateError: getStateErrorByFailure(failure),
+      failure: failure,
+    ));
+
+    _emitStateErrorCleanerState();
+
+    return true;
+  }
+
+  @protected
+  BaseStateError getStateErrorByFailure(Failure failure) {
+    return switch (failure) {
+      RemoteFailure() => BaseStateError.remote,
+      UnknownFailure() => BaseStateError.unknown,
+    };
+  }
+
+  void _emitStateErrorCleanerState() {
+    emit(
+      state.copyWithError(
+        stateError: BaseStateError.none,
+      ),
+    );
+  }
+}

--- a/lib/app/core/controller/base/base_state_error.dart
+++ b/lib/app/core/controller/base/base_state_error.dart
@@ -1,0 +1,9 @@
+import 'package:match/match.dart';
+
+@match
+enum BaseStateError {
+  none,
+  unknown,
+  remote,
+  //TODO add here common errors for the app, such as internetConnection?
+}

--- a/lib/app/core/result/failure.dart
+++ b/lib/app/core/result/failure.dart
@@ -1,0 +1,29 @@
+import 'package:equatable/equatable.dart';
+
+sealed class Failure extends Equatable {}
+
+class RemoteFailure extends Failure {
+  final String message;
+
+  RemoteFailure({
+    required this.message,
+  });
+
+  @override
+  List<Object?> get props => [
+        message,
+      ];
+}
+
+class UnknownFailure extends Failure {
+  final dynamic exception;
+
+  UnknownFailure({
+    required this.exception,
+  });
+
+  @override
+  List<Object?> get props => [
+        exception,
+      ];
+}

--- a/lib/app/core/result/result.dart
+++ b/lib/app/core/result/result.dart
@@ -1,0 +1,46 @@
+import 'package:app_flutter_arch/app/core/result/failure.dart';
+import 'package:equatable/equatable.dart';
+
+enum Status {
+  success,
+  failure,
+}
+
+class Result<D> extends Equatable {
+  final Status status;
+  final D? data;
+  final Failure? failure;
+
+  const Result._({
+    required this.status,
+    this.data,
+    this.failure,
+  });
+
+  factory Result.success({
+    required D data,
+  }) {
+    return Result._(
+      status: Status.success,
+      data: data,
+    );
+  }
+
+  factory Result.fail({
+    required Failure failure,
+  }) {
+    return Result._(
+      status: Status.failure,
+      failure: failure,
+    );
+  }
+
+  bool isSuccess() => status == Status.success;
+
+  @override
+  List<Object?> get props => <Object?>[
+        status,
+        data,
+        failure,
+      ];
+}

--- a/lib/app/core/ui/helpers/messages.dart
+++ b/lib/app/core/ui/helpers/messages.dart
@@ -1,8 +1,18 @@
+import 'package:app_flutter_arch/app/core/result/failure.dart';
 import 'package:app_flutter_arch/app/core/ui/styles/colors_app.dart';
 import 'package:another_flushbar/flushbar.dart';
 import 'package:flutter/material.dart';
 
 mixin Messages<T extends StatefulWidget> on State<T> {
+  void showFailureError(Failure? failure) {
+    final String? errorMessage = switch (failure) {
+      RemoteFailure() => failure.message,
+      UnknownFailure() => null,
+      null => null,
+    };
+    showError(errorMessage ?? 'Erro não informado');
+  }
+
   void showError(String message) {
     Flushbar(
       backgroundColor: ColorsApp.instance.red,

--- a/lib/app/pages/home/home_controller.dart
+++ b/lib/app/pages/home/home_controller.dart
@@ -1,32 +1,25 @@
-import 'package:app_flutter_arch/app/core/exceptions/repository_exception.dart';
-import 'package:bloc/bloc.dart';
+import 'package:app_flutter_arch/app/core/controller/base/base_cubit_controller.dart';
 
 import 'package:app_flutter_arch/app/pages/home/home_state.dart';
 import 'package:app_flutter_arch/app/repositories/repositoryExample/repository_example.dart';
 
-class HomeController extends Cubit<HomeState> {
+class HomeController extends BaseCubitController<HomeState> {
   final RepositoryExample _repositoryExample;
 
   HomeController(
     this._repositoryExample,
-  ) : super(const HomeState.initial());
+  ) : super(HomeState.initial());
 
   Future<void> loadItems() async {
     emit(state.copyWith(status: HomeStateStatus.loading));
-    try {
-      final products = await _repositoryExample.findAllItems();
 
-      emit(state.copyWith(status: HomeStateStatus.loaded, products: products));
-    } on RepositoryException catch (e) {
-      final errorMessage = e.message;
+    final productsResult = await _repositoryExample.findAllItems();
+    if (emitStateIfFailure(productsResult)) return;
 
-      emit(
-        state.copyWith(
-          status: HomeStateStatus.error,
-          errorMessage: errorMessage,
-        ),
-      );
-    }
+    emit(state.copyWith(
+      status: HomeStateStatus.loaded,
+      products: productsResult.data,
+    ));
   }
 
   Future<void> login({

--- a/lib/app/pages/home/home_page.dart
+++ b/lib/app/pages/home/home_page.dart
@@ -31,7 +31,7 @@ class _HomePageState extends BasePage<HomePage, HomeController> {
             loading: () => showLoader(),
             error: () {
               hideLoader();
-              showError(state.errorMessage ?? 'Erro não informado');
+              showFailureError(state.failure);
             },
           );
         },

--- a/lib/app/pages/home/home_state.dart
+++ b/lib/app/pages/home/home_state.dart
@@ -1,4 +1,6 @@
-import 'package:equatable/equatable.dart';
+import 'package:app_flutter_arch/app/core/controller/base/base_controller_state.dart';
+import 'package:app_flutter_arch/app/core/controller/base/base_state_error.dart';
+import 'package:app_flutter_arch/app/core/result/failure.dart';
 import 'package:match/match.dart';
 
 import 'package:app_flutter_arch/app/dto/dto_example.dart';
@@ -18,28 +20,35 @@ enum HomeStateStatus {
   noError,
 }
 
-class HomeState extends Equatable {
+class HomeState extends BaseControllerState<HomeState> {
   final HomeStateStatus status;
   final List<ModelExample> itemExample;
-  final String? errorMessage;
   final List<ExampleDto> listSavedOnStoreExample;
 
   const HomeState({
     required this.status,
     required this.itemExample,
     required this.listSavedOnStoreExample,
-    this.errorMessage,
+    super.stateError = BaseStateError.none,
+    super.failure,
   });
 
-  const HomeState.initial()
-      : status = HomeStateStatus.initial,
-        itemExample = const [],
-        listSavedOnStoreExample = const [],
-        errorMessage = null;
+  factory HomeState.initial() {
+    return const HomeState(
+      status: HomeStateStatus.initial,
+      itemExample: [],
+      listSavedOnStoreExample: [],
+    );
+  }
 
   @override
   List<Object?> get props =>
-      [status, itemExample, errorMessage, listSavedOnStoreExample];
+      [
+        super.props,
+        status,
+        itemExample,
+        listSavedOnStoreExample,
+      ];
 
   HomeState copyWith({
     HomeStateStatus? status,
@@ -49,10 +58,25 @@ class HomeState extends Equatable {
   }) {
     return HomeState(
       status: status ?? this.status,
-      itemExample: products ?? this.itemExample,
-      errorMessage: errorMessage ?? this.errorMessage,
+      itemExample: products ?? itemExample,
       listSavedOnStoreExample:
           listSavedOnStoreExample ?? this.listSavedOnStoreExample,
+      failure: failure,
+      stateError: stateError,
+    );
+  }
+
+  @override
+  HomeState copyWithError({
+    BaseStateError? stateError,
+    Failure? failure,
+  }) {
+    return HomeState(
+      status: HomeStateStatus.error,
+      itemExample: itemExample,
+      listSavedOnStoreExample: listSavedOnStoreExample,
+      failure: failure ?? this.failure,
+      stateError: stateError ?? this.stateError,
     );
   }
 }

--- a/lib/app/pages/home/widgets/home_body.dart
+++ b/lib/app/pages/home/widgets/home_body.dart
@@ -1,6 +1,7 @@
 import 'package:app_flutter_arch/app/core/ui/base_state/base_state.dart';
 import 'package:app_flutter_arch/app/core/ui/base_state/state_with_controller.dart';
 import 'package:app_flutter_arch/app/core/ui/helpers/size_extensions.dart';
+import 'package:app_flutter_arch/app/core/ui/widgets/button_example.dart';
 import 'package:app_flutter_arch/app/core/ui/widgets/generic_input.dart';
 import 'package:app_flutter_arch/app/pages/home/home_controller.dart';
 import 'package:flutter/material.dart';
@@ -54,6 +55,11 @@ class _HomeBodyState extends BaseState<HomeBody>
                 controller: _passwordController,
                 focusNode: _passwordFocusNode,
                 onFieldSubmitted: (term) => _onLoginButtonPressed(),
+              ),
+              ButtonExample(
+                width: context.percentWidth(.9),
+                label: 'Login',
+                onPressed: _onLoginButtonPressed,
               ),
             ],
           ),

--- a/lib/app/repositories/repositoryExample/repository_example.dart
+++ b/lib/app/repositories/repositoryExample/repository_example.dart
@@ -1,5 +1,7 @@
+import 'package:app_flutter_arch/app/core/result/result.dart';
+
 import '../../models/model_example.dart';
 
 abstract class RepositoryExample {
-  Future<List<ModelExample>> findAllItems();
+  Future<Result<List<ModelExample>>> findAllItems();
 }

--- a/lib/app/repositories/repositoryExample/repository_example_impl.dart
+++ b/lib/app/repositories/repositoryExample/repository_example_impl.dart
@@ -2,9 +2,10 @@ import 'dart:developer';
 
 import 'package:app_flutter_arch/app/data_sources/remote_data_source/remote_data_source.dart';
 import 'package:app_flutter_arch/app/models/model_example.dart';
-
-import '../../core/exceptions/repository_exception.dart';
-import './repository_example.dart';
+import 'package:app_flutter_arch/app/core/result/failure.dart';
+import 'package:app_flutter_arch/app/core/result/result.dart';
+import 'package:app_flutter_arch/app/repositories/repositoryExample/repository_example.dart';
+import 'package:dio/dio.dart';
 
 class RepositoryExampleImpl implements RepositoryExample {
   final RemoteDataSource remoteDataSource;
@@ -14,13 +15,23 @@ class RepositoryExampleImpl implements RepositoryExample {
   });
 
   @override
-  Future<List<ModelExample>> findAllItems() async {
+  Future<Result<List<ModelExample>>> findAllItems() async {
     try {
-      //TODO: check if network is available. If not, get from localRemoteDataSource
-      return await remoteDataSource.findAllItems();
+      final modelExamples = await remoteDataSource.findAllItems();
+      return Result.success(data: modelExamples);
+    } on DioException catch (e, s) {
+      log('Erro de API ao buscar items', error: e, stackTrace: s);
+      return Result.fail(
+        failure: RemoteFailure(message: 'Erro ao buscar items'),
+      );
     } catch (e, s) {
-      log('Erro ao buscar items', error: e, stackTrace: s);
-      throw RepositoryException(message: 'Erro ao buscar items');
+      log('Erro desconhecido ao buscar items', error: e, stackTrace: s);
+      return Result.fail(
+        failure: RemoteFailure(message: 'Erro ao buscar items'),
+      );
     }
+    //TODO esse try catch vai se repetir em muitos repositories. Acho que vale
+    //criar um BaseRepository que faça um mapeamento default que possa ser
+    //sobresscrito eventualmente.
   }
 }


### PR DESCRIPTION
Acho que a parte de `try catch` dentro das Controllers (Cubit/Bloc) podem ser um problema pq no geral eles acabam aumentando a dificuldade pra compreender o que o método faz no geral, isso pq ele acaba aumentando o nível de aninhamento do método.

E para poder modularizar essa parte numa classe base, só é possível se enveloparmos a chamada passando a função como parâmetro (o que acaba mantendo o nível de aninhamento).

Uma estratégia bem legal que vi o pessoal adotando é transformar `Exceptions/Erros` em `Failures` um momento antes da camada de data/domain repassar o resultado para a camada de `presentation`. Aí desse jeito conseguimos modularizar num `BaseController` da vida de um jeito mais fácil.

Então, a ideia foi:
1. Criar uma classe abstrata de `Failure`;
2. Criar uma classe de `Result` que pode conter o dado real (quando for sucesso) e uma `Failure` quando alguma coisa deu errado;
3. Refatorar o `Repository` para retornar um `Result` e então mapear `Esceptions` no `try catch` em `Failures`;
4. Criar um `BaseCubitController` que emite um estado de um jeito padrão (e que pode ser sobreescrito) no caso de falhas. Isso exigiu criar um `BaseControllerState` tbm para forçar todos os estados terem a propriedade de enum de erro e da failure; e
5. Extender o `BaseCubitController` pelo `HomeController`.

Então a grande vantagem no final é o código mais enxuto e simples de entender sem `try catches` que vamos ter nos Controllers:

<img width="1314" alt="Screenshot 2023-09-01 at 00 13 26" src="https://github.com/cpvasques/flutterArch/assets/11656791/98157445-5928-4d31-b761-8bdffaf2a522">

Um TODO interessante que vou deixar é pensar num `BaseRepository` pra ter o mapeamento de exceptions para failures de um jeito reaproveitável entre os métodos e repositories.

Desculpa o tamanho do PR.

